### PR TITLE
huawei: Set ME936 (12d1:15bb) to MBIM mode

### DIFF
--- a/plugins/huawei/77-mm-huawei-net-port-types.rules
+++ b/plugins/huawei/77-mm-huawei-net-port-types.rules
@@ -6,6 +6,9 @@ ENV{ID_VENDOR_ID}!="12d1", GOTO="mm_huawei_port_types_end"
 # MU609 does not support getportmode (crashes modem with default firmware)
 ATTRS{idProduct}=="1573", ENV{ID_MM_HUAWEI_DISABLE_GETPORTMODE}="1"
 
+# ME936 only works in MBIM mode
+SUBSYSTEM=="usb", ATTR{idProduct}=="15bb", ATTR{bNumConfigurations}=="3", ATTR{bConfigurationValue}!="3", ATTR{bConfigurationValue}="3"
+
 # Mark the modem and at port flags for ModemManager
 SUBSYSTEMS=="usb", ATTRS{bInterfaceClass}=="ff", ATTRS{bInterfaceSubClass}=="01", ATTRS{bInterfaceProtocol}=="01", ENV{ID_MM_HUAWEI_MODEM_PORT}="1"
 SUBSYSTEMS=="usb", ATTRS{bInterfaceClass}=="ff", ATTRS{bInterfaceSubClass}=="01", ATTRS{bInterfaceProtocol}=="02", ENV{ID_MM_HUAWEI_AT_PORT}="1"


### PR DESCRIPTION
This device only works correctly in MBIM mode. To have the device in
MBIM mode we need to set bConfiguration=3.

https://phabricator.endlessm.com/T16335